### PR TITLE
Cleanup tests for MicroPython v1.13 

### DIFF
--- a/test/test_server.py
+++ b/test/test_server.py
@@ -288,14 +288,11 @@ class ServerFull(unittest.TestCase):
     def setUp(self):
         self.dummy_called = False
         self.data = {}
-        # "Register" one connection into map for dedicated decor server
-        server_for_decorators.conns[id(1)] = None
         self.hello_world_history = ['HTTP/1.0 200 MSG\r\n' +
                                     'Content-Type: text/html\r\n\r\n',
                                     '<html><h1>Hello world</h1></html>']
         # Create one more server - to simplify bunch of tests
         self.srv = webserver()
-        self.srv.conns[id(1)] = None
 
     def testRouteDecorator1(self):
         """Test @.route() decorator"""
@@ -317,8 +314,6 @@ class ServerFull(unittest.TestCase):
         rdr = mockReader(['GET /uid2/man2 HTTP/1.1\r\n',
                           HDRE])
         wrt = mockWriter()
-        # Re-register connection
-        server_for_decorators.conns[id(1)] = None
         # "Send" request
         run_coro(server_for_decorators._handler(rdr, wrt))
         # Ensure that proper response "sent"
@@ -537,7 +532,6 @@ class ServerFull(unittest.TestCase):
         self.assertTrue(wrt.closed)
 
         # "Send" GET request to POST only location
-        self.srv.conns[id(1)] = None
         self.dummy_called = False
         rdr = mockReader(['GET /post_only HTTP/1.1\r\n',
                           HDRE])
@@ -645,7 +639,6 @@ class ServerResource(unittest.TestCase):
 
     def setUp(self):
         self.srv = webserver()
-        self.srv.conns[id(1)] = None
         self.srv.add_resource(ResourceGetPost, '/')
         self.srv.add_resource(ResourceGetParam, '/param/<user_id>')
         self.srv.add_resource(ResourceGetArgs, '/args', arg1=1, arg2=2)
@@ -778,7 +771,6 @@ class StaticContent(unittest.TestCase):
 
     def setUp(self):
         self.srv = webserver()
-        self.srv.conns[id(1)] = None
         self.tempfn = '__tmp.html'
         self.ctype = None
         self.etype = None

--- a/tinyci
+++ b/tinyci
@@ -1,0 +1,28 @@
+#! /bin/sh
+#
+# tinyci
+#
+#
+#
+# Simple test runner that watches for changes and runs
+#
+#    ./tinyci
+#
+# Get a unix port of micropython using pyenv https://github.com/pyenv/pyenv
+#
+# Install all the dependencies needed using upip
+#
+#    PYENV_VERSION=micropython-1.13 python -m upip install -p ./lib unittest uasyncio
+#
+# You may need to install the inotifywait command for your environment. 
+#
+# type inotifywait || echo "inotify-tools is not installed" && exit 1
+
+while true
+do
+    inotifywait -q -q -r -e 'close_write' \
+        --exclude '^\..*\.sw[px]*$|4913|~$|.git/.*\.lock$|.*i\.log$|spec/fixtures|build/|_trial_temp*' .
+    sleep 1
+    printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' =
+    PYENV_VERSION=micropython-1.13 python -c "import unittest; unittest.main('test/test_server')"
+done

--- a/tinyweb/server.py
+++ b/tinyweb/server.py
@@ -372,20 +372,14 @@ class webserver:
         Keyword arguments:
             request_timeout - Time for client to send complete request
                               after that connection will be closed.
-            max_concurrency - How many connections can be processed concurrently.
-                              It is very important to limit this number because of
-                              memory constrain.
-                              Default value depends on platform
             backlog         - Parameter to socket.listen() function. Defines size of
                               pending to be accepted connections queue.
-                              Must be greater than max_concurrency
             debug           - Whether send exception info (text + backtrace)
                               to client together with HTTP 500 or not.
         """
         self.host = host
         self.port = port
         self.request_timeout = request_timeout
-        self.max_concurrency = max_concurrency
         self.backlog = backlog
         self.debug = debug
         self.explicit_url_map = {}

--- a/tinyweb/server.py
+++ b/tinyweb/server.py
@@ -446,7 +446,7 @@ class webserver:
             resp = response(writer)
             # Read HTTP Request with timeout
             await uasyncio.wait_for(self._handle_request(req, resp),
-                                   self.request_timeout)
+                                    self.request_timeout)
 
             # OPTIONS method is handled automatically
             if req.method == b'OPTIONS':


### PR DESCRIPTION
Fixes #29  Looks like the code on this branch works fine with the new asyncio in 1.13. I have only done a minor cleanup of tests. 

https://travis-ci.com/github/timhughes/tinyweb

I have added a script for a local CI using the unix port. You may not want it but it helps me iterate through errors rapidly - it only runs on Linux because it depends on inotify. Feel free to tell me to delete.

Tested on an ESP32 with MicroPython v1.13 using `esp32-idf3-20200902-v1.13.bin `

The following is the way i tested it which may be useful to add to `CONTRIBUTING.txt`

Copy files onto board
```
thughes@silicon [0] $ rshell -p /dev/ttyUSB0 rm -rf /pyboard/*
thughes@silicon [0] $ rshell -p /dev/ttyUSB0 mkdir /pyboard/lib
thughes@silicon [0] $ rshell -p /dev/ttyUSB0 cp lib/unittest.py /pyboard/lib/
thughes@silicon [0] $ rshell -p /dev/ttyUSB0 cp -r tinyweb test /pyboard/
```
Run Tests
```
thughes@silicon [0] $ pyboard --device /dev/ttyUSB0 -b 115200 -c 'import sys;from test.test_server import *; print("=== %s v%s on %s ===" % (sys.implementation[0], ".".join([str(c) for c in sys.implementation[1]]), sys.platform)); unittest.main();'
=== micropython v1.13.0 on esp32 ===
testUrldecode (Utils) ... ok
testParseQueryString (Utils) ... ok
testRequestLine (ServerParts) ... ok
testRequestLineEmptyLinesBefore (ServerParts) ... ok
testRequestLineNegative (ServerParts) ... ok
testHeadersSimple (ServerParts) ... ok
testHeadersSpaces (ServerParts) ... ok
testHeadersEmptyValue (ServerParts) ... ok
testHeadersMultiple (ServerParts) ... ok
testUrlFinderExplicit (ServerParts) ... ok
testUrlFinderParameterized (ServerParts) ... ok
testUrlFinderNegative (ServerParts) ... ok
testRouteDecorator1 (ServerFull) ... ok
testRouteDecorator2 (ServerFull) ... ok
testResourceDecorator1 (ServerFull) ... ok
testResourceDecorator2 (ServerFull) ... ok
testStartHTML (ServerFull) ... ok
testRedirect (ServerFull) ... ok
testRequestBodyUnknownType (ServerFull) ... ok
testRequestBodyJson (ServerFull) ... ok
testRequestBodyUrlencoded (ServerFull) ... ok
testRequestBodyNegative (ServerFull) ... ok
testRequestLargeBody (ServerFull) ... ok
testRouteParameterized (ServerFull) ... ok
testParseHeadersOnOff (ServerFull) ... ok
testDisallowedMethod (ServerFull) ... ok
testAutoOptionsMethod (ServerFull) ... ok
testPageNotFound (ServerFull) ... ok
testMalformedRequest (ServerFull) ... ok
testOptions (ServerResource) ... ok
testGet (ServerResource) ... ok
testGetWithParam (ServerResource) ... ok
testGetWithArgs (ServerResource) ... ok
testGenerator (ServerResource) ... ok
testPost (ServerResource) ... ok
testInvalidMethod (ServerResource) ... ok
testException (ServerResource) ...ERROR: something
 ok
testBrokenPipe (ServerResource) ... ok
testSendFileManual (StaticContent) ... ok
testSendFileNotFound (StaticContent) ... ok
testSendFileConnectionReset (StaticContent) ... ok
Ran 41 tests

OK


```