### PR TITLE
Added @catchall decorator, to serve custom 404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__
+/_test

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ By itself - *tinyweb* is just simple TCP server running on top of `uasyncio` - l
 * Great unittest coverage. So you can be confident about quality :)
 
 ### Requirements
+
+* [logging](https://github.com/micropython/micropython-lib/tree/master/logging)
+
+On MicroPython <1.13:
+
 * [uasyncio](https://github.com/micropython/micropython-lib/tree/master/uasyncio) - micropython version of *async* python library.
 * [uasyncio-core](https://github.com/micropython/micropython-lib/tree/master/uasyncio.core)
-* [logging](https://github.com/micropython/micropython-lib/tree/master/logging)
 
 ### Quickstart
 The easist way to try it - is using pre-compiled firmware for ESP8266 / ESP32.


### PR DESCRIPTION
I've added an `@catchall` decorator which works very similar to `@route`. The handler is called on every 404, giving users to ability to serve custom 404 pages and status codes (also useful for captive portals).

Not sure if you want to add this, but I think it's very useful and wanted to offer this contribution :) If you want it, I can add  tests and docs too. 

```python
@app.catchall()
def catchall_handler(req, resp):
    response.code = 404
    await response.start_html()
    await response.send('<html><body><h1>My custom 404!</h1></html>\n')
```