### PR TITLE
Fix generator_type fix

### DIFF
--- a/tinyweb/server.py
+++ b/tinyweb/server.py
@@ -16,6 +16,8 @@ import usocket as socket
 
 log = logging.getLogger('WEB')
 
+type_gen = type((lambda: (yield))())
+
 # uasyncio v3 is shipped with MicroPython 1.13, and contains some subtle
 # but breaking changes. See also https://github.com/peterhinch/micropython-async/blob/master/v3/README.md
 IS_UASYNCIO_V3 = hasattr(asyncio, "__version__") and asyncio.__version__ >= (3,)
@@ -328,7 +330,6 @@ async def restful_resource_handler(req, resp, param=None):
     # it can also return error code together with str / dict
     # res = {'blah': 'blah'}
     # res = {'blah': 'blah'}, 201
-    type_gen = type((lambda: (yield))())
     if isinstance(res, type_gen):
         # Result is generator, use chunked response
         # NOTICE: HTTP 1.0 by itself does not support chunked responses, so, making workaround:

--- a/tinyweb/server.py
+++ b/tinyweb/server.py
@@ -328,7 +328,8 @@ async def restful_resource_handler(req, resp, param=None):
     # it can also return error code together with str / dict
     # res = {'blah': 'blah'}
     # res = {'blah': 'blah'}, 201
-    if isinstance(res, asyncio.type_gen):
+    type_gen = type((lambda: (yield))())
+    if isinstance(res, type_gen):
         # Result is generator, use chunked response
         # NOTICE: HTTP 1.0 by itself does not support chunked responses, so, making workaround:
         # Response is HTTP/1.1 with Connection: close


### PR DESCRIPTION
The example [here](https://github.com/belyalov/tinyweb/blob/master/examples/rest_api.py) does not work for me as expected.

I encountered an error when checking the type the `res`.

I'm running `MicroPython v1.13` and both `>>> import uasyncio as asyncio` `>>> import uasyncio.core` run as expected. My uasyncio version appears to be `(3, 0, 0)`.

This change also appears to be implemented in (https://github.com/belyalov/tinyweb/blob/new_uasync_io/tinyweb/server.py) but is a stand-alone fix.

I see that this method is also how the `type_gen` is created by uasyncio.core [here](https://github.com/micropython/micropython-lib/blob/master/uasyncio.core/uasyncio/core.py), but does not appear present in my version

```python
>>> import uasyncio.core.
__class__       __name__        __file__        CancelledError
Task            TaskQueue       _task_queue     cur_task
run             select          sleep           sleep_ms
sys             ticks_add       ticks_diff      ticks
TimeoutError    _exc_context    SingletonGenerator
IOQueue         _promote_to_task                create_task
run_until_complete              _stopper        _stop_task
Loop            get_event_loop  new_event_loop  _io_queue

```

I'm happy to close/modify/raise an issue instead, but the included fix was necessary for me to work based on current documentation in the readme.

I also don't trust myself enough to write tests that spin up the server and check these types so I'm leaving off.

Happy holidays!