### PR TITLE
Bug fix:  asyncio.cancel

### DIFF
--- a/tinyweb/server.py
+++ b/tinyweb/server.py
@@ -153,7 +153,7 @@ class request:
             # Re-generate exception for malformed form data
             raise HTTPException(400)
 
-    async def read_parse_query_data(self):
+    def read_parse_query_data(self):
         return parse_query_string(self.query_string.decode())
 
 


### PR DESCRIPTION
- Replaced asyncio.cancel with task.cancel and now storing tasks in self.conns instead of handlers.
- Check web server is running before shutting down and is not running before starting.
- Removed unused self.processed_connections in webserver class.
