### PR TITLE
Adjust log.exc to log.exception

### DIFF
--- a/tinyweb/server.py
+++ b/tinyweb/server.py
@@ -476,16 +476,16 @@ class webserver:
                 try:
                     await resp.error(500)
                 except Exception as e:
-                    log.exc(e, "")
+                    log.exception(f"Failed to send 500 error after OSError. Original error: {e}")
         except HTTPException as e:
             try:
                 await resp.error(e.code)
             except Exception as e:
-                log.exc(e)
+                log.exception(f"Failed to send error after HTTPException. Original error: {e}")
         except Exception as e:
             # Unhandled expection in user's method
             log.error(req.path.decode())
-            log.exc(e, "")
+            log.exception(f"Unhandled exception in user's method. Original error: {e}")
             try:
                 await resp.error(500)
                 # Send exception info if desired


### PR DESCRIPTION
Logging module dropped support for exc. These adjustments use the exception method instead. This relates to #58 